### PR TITLE
#818 halve iterations for nested functional tests

### DIFF
--- a/pfunk/tests/nested_banana.py
+++ b/pfunk/tests/nested_banana.py
@@ -80,7 +80,7 @@ class NestedBanana(pfunk.FunctionalTest):
             sampler.set_log_to_screen(False)
 
         # Set max iterations
-        sampler.set_iterations(8000)
+        sampler.set_iterations(4000)
         sampler.set_posterior_samples(2000)
 
         # Run

--- a/pfunk/tests/nested_egg_box.py
+++ b/pfunk/tests/nested_egg_box.py
@@ -73,7 +73,7 @@ class NestedEggBox(pfunk.FunctionalTest):
             sampler.set_log_to_screen(False)
 
         # Set max iterations
-        sampler.set_iterations(8000)
+        sampler.set_iterations(4000)
         sampler.set_posterior_samples(2000)
 
         # Run


### PR DESCRIPTION
See https://github.com/pints-team/pints/issues/818

The other nested test (`nested_normal.py`) already had fewer iterations, so leaving that one for now.