### PR TITLE
Pfunk parallel

### DIFF
--- a/pfunk/__main__.py
+++ b/pfunk/__main__.py
@@ -108,9 +108,9 @@ def run(args):
     for name in names:
 
         # Run the test args.r times in parallel
-        print('Running test {} {} times'.format(name, args.r))
-        pool = mp.Pool(min(args.r, mp.cpu_count() - 2))
-        pool.map(pfunk.tests.run, [name] * args.r)
+        with mp.Pool(processes=min(args.r, mp.cpu_count() - 2)) as pool:
+            print('Running test {} {} times with {} processes'.format(name, args.r, pool._processes))
+            pool.map(pfunk.tests.run, [name] * args.r)
 
         if args.analyse:
             print('Analysing ' + name + ' ... ', end='')

--- a/pfunk/__main__.py
+++ b/pfunk/__main__.py
@@ -15,6 +15,8 @@ import os
 import subprocess
 import sys
 
+import multiprocessing as mp
+
 import pfunk
 import pfunk.tests
 
@@ -104,13 +106,17 @@ def run(args):
 
     # Run tests
     for name in names:
-        for i in range(args.r):
-            print('Running test ' + name)
-            pfunk.tests.run(name)
+
+        # Run the test args.r times in parallel
+        print('Running test {} {} times'.format(name, args.r)
+        pool = mp.Pool(min(args.r, mp.cpu_count() - 2))
+        pool.map(pfunk.tests.run, [name] * args.r)
+
         if args.analyse:
             print('Analysing ' + name + ' ... ', end='')
             result = pfunk.tests.analyse(name)
             print('ok' if result else 'FAIL')
+
         if args.plot or args.show:
             print('Creating plot for ' + name)
             pfunk.tests.plot(name, args.show)

--- a/pfunk/__main__.py
+++ b/pfunk/__main__.py
@@ -108,7 +108,7 @@ def run(args):
     for name in names:
 
         # Run the test args.r times in parallel
-        print('Running test {} {} times'.format(name, args.r)
+        print('Running test {} {} times'.format(name, args.r))
         pool = mp.Pool(min(args.r, mp.cpu_count() - 2))
         pool.map(pfunk.tests.run, [name] * args.r)
 

--- a/pfunk/__main__.py
+++ b/pfunk/__main__.py
@@ -13,11 +13,11 @@ from itertools import product
 
 import argparse
 import fnmatch
+import multiprocessing
 import os
 import subprocess
 import sys
 
-import multiprocessing as mp
 
 import pfunk
 import pfunk.tests
@@ -110,7 +110,7 @@ def run(args):
     for name in names:
 
         # Run the test args.r times in parallel
-        with mp.Pool(processes=min(args.r, mp.cpu_count() - 2)) as pool:
+        with multiprocessing.Pool(processes=min(args.r, multiprocessing.cpu_count() - 2)) as pool:
             print('Running {} {} times with {} processes:'.format(name, args.r, pool._processes))
 
             # Starmap with product of name and range: -> [(name, 0), (name, 1), ...]

--- a/pfunk/__main__.py
+++ b/pfunk/__main__.py
@@ -9,6 +9,8 @@
 from __future__ import absolute_import, division
 from __future__ import print_function, unicode_literals
 
+from itertools import product
+
 import argparse
 import fnmatch
 import os
@@ -109,8 +111,10 @@ def run(args):
 
         # Run the test args.r times in parallel
         with mp.Pool(processes=min(args.r, mp.cpu_count() - 2)) as pool:
-            print('Running test {} {} times with {} processes'.format(name, args.r, pool._processes))
-            pool.map(pfunk.tests.run, [name] * args.r)
+            print('Running {} {} times with {} processes:'.format(name, args.r, pool._processes))
+
+            # Starmap with product of name and range: -> [(name, 0), (name, 1), ...]
+            pool.starmapmap(pfunk.tests.run, product([name], range(args.r)))
 
         if args.analyse:
             print('Analysing ' + name + ' ... ', end='')

--- a/pfunk/__main__.py
+++ b/pfunk/__main__.py
@@ -114,7 +114,7 @@ def run(args):
             print('Running {} {} times with {} processes:'.format(name, args.r, pool._processes))
 
             # Starmap with product of name and range: -> [(name, 0), (name, 1), ...]
-            pool.starmapmap(pfunk.tests.run, product([name], range(args.r)))
+            pool.starmap(pfunk.tests.run, product([name], range(args.r)))
 
         if args.analyse:
             print('Analysing ' + name + ' ... ', end='')

--- a/pfunk/tests/_tests.py
+++ b/pfunk/tests/_tests.py
@@ -23,9 +23,9 @@ def tests():
     return sorted(_tests.keys())
 
 
-def run(name):
+def run(name, run_number=0):
     """ Runs a selected test. """
-    print('Running test {}'.format(name))
+    print('Running test {} run {}'.format(name, run_number))
     _tests[name].run()
 
 

--- a/pfunk/tests/_tests.py
+++ b/pfunk/tests/_tests.py
@@ -25,6 +25,7 @@ def tests():
 
 def run(name):
     """ Runs a selected test. """
+    print('Running test {}'.format(name))
     _tests[name].run()
 
 

--- a/pfunk/tests/mcmc_banana.py
+++ b/pfunk/tests/mcmc_banana.py
@@ -89,7 +89,7 @@ class MCMCBanana(pfunk.FunctionalTest):
 
         # Set up a sampling routine
         mcmc = MCMCController(log_pdf, self._nchains, x0, method=method)
-        mcmc.set_parallel(True)
+        mcmc.set_parallel(False) # functional testing defaults to 5 runs in parallel
 
         # Log to file
         if not DEBUG:

--- a/pfunk/tests/mcmc_egg_box.py
+++ b/pfunk/tests/mcmc_egg_box.py
@@ -77,7 +77,7 @@ class MCMCEggBox(pfunk.FunctionalTest):
 
         # Set up a sampling routine
         mcmc = pints.MCMCController(log_pdf, self._nchains, x0, method=method)
-        mcmc.set_parallel(True)
+        mcmc.set_parallel(False) # functional testing defaults to 5 runs in parallel
 
         # Log to file
         if not DEBUG:

--- a/pfunk/tests/mcmc_normal.py
+++ b/pfunk/tests/mcmc_normal.py
@@ -81,7 +81,7 @@ class MCMCNormal(pfunk.FunctionalTest):
         # Create a sampling routine
         mcmc = pints.MCMCController(
             log_pdf, self._nchains, x0, sigma0=sigma, method=method)
-        mcmc.set_parallel(True)
+        mcmc.set_parallel(False) # functional testing defaults to 5 runs in parallel
 
         # Log to file
         if not DEBUG:

--- a/pfunk/tests/optimisation.py
+++ b/pfunk/tests/optimisation.py
@@ -68,11 +68,8 @@ class Optimisation(pfunk.FunctionalTest):
         evaluations = 0
         unchanged_iterations = 0
 
-        # Create parallel evaluator
-        n_workers = pints.ParallelEvaluator.cpu_count()
-        if isinstance(optimiser, pints.PopulationBasedOptimiser):
-            n_workers = min(n_workers, optimiser.population_size())
-        evaluator = pints.ParallelEvaluator(score, n_workers=n_workers)
+        # Create sequential evaluator (functional testing defaults to 5 runs in parallel)
+        evaluator = pints.SequentialEvaluator(score)
 
         # Keep track of best position and score
         fbest = float('inf')


### PR DESCRIPTION
The functional tests each run 5 times, and this is trivially parallel.

These changes turn off parallelism in each test and use multiprocessing instead to kick off each of the runs in parallel.

An example speedup, even for an optimisation test where the change is from a parallel to sequential evaluator, is ~2.4x.